### PR TITLE
give DateButton enough preferred width on hi-dpi screens

### DIFF
--- a/sierra/src/main/java/org/httprpc/sierra/DatePicker.java
+++ b/sierra/src/main/java/org/httprpc/sierra/DatePicker.java
@@ -45,7 +45,7 @@ public class DatePicker extends Picker {
             LocalDate date = null;
 
             DateButton() {
-                super("00");
+                super("000"); // give enough space for hi-dpi screens
 
                 putClientProperty("JButton.buttonType", "toolBarButton");
 


### PR DESCRIPTION
I found an issue, when the datepicker's popup is displayed on a hi-dpi screen (see screenshot).
On Windows this happens e.g. if the monitor settings are 125%.
![datepicker-125](https://github.com/user-attachments/assets/59ea7a30-4f1a-41b1-9c0f-c0c4fffe930a)
