### PR TITLE
Add module-info

### DIFF
--- a/sierra/src/main/java/module-info.java
+++ b/sierra/src/main/java/module-info.java
@@ -1,6 +1,5 @@
-module sierra {
+module org.httprpc.sierra {
     requires transitive java.desktop;
 
     exports org.httprpc.sierra;
-
 }

--- a/sierra/src/main/java/module-info.java
+++ b/sierra/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module sierra {
+    requires transitive java.desktop;
+
+    exports org.httprpc.sierra;
+
+}


### PR DESCRIPTION
Add `module-info.java`. 

This packages Sierra as a Java 9 module, allowing it to be used in modular projects. Also, apps built with Sierra can be easily included in [Jlink deployments](https://docs.oracle.com/en/java/javase/11/tools/jlink.html), a benefit when running Swing-based apps on the desktop.
