### PR TITLE
Remove redundant null check on UILoader.load

### DIFF
--- a/sierra/src/main/java/org/httprpc/sierra/UILoader.java
+++ b/sierra/src/main/java/org/httprpc/sierra/UILoader.java
@@ -956,6 +956,8 @@ public class UILoader {
     private URL getURL(String name) {
         if (owner != null) {
             return owner.getClass().getResource(name);
+        } else if (owner == null && path == null) {
+            return ClassLoader.getSystemResource(name);
         } else {
             var uri = path.resolveSibling(name).toUri();
 

--- a/sierra/src/main/java/org/httprpc/sierra/UILoader.java
+++ b/sierra/src/main/java/org/httprpc/sierra/UILoader.java
@@ -970,6 +970,19 @@ public class UILoader {
     /**
      * Deserializes a component hierarchy from a markup document.
      *
+     * @param name
+     * The name of the document, relative to the owner's type.
+     *
+     * @return
+     * The deserialized component hierarchy.
+     */
+    public static JComponent load(String name) {
+        return load(null, name, null);
+    }
+
+    /**
+     * Deserializes a component hierarchy from a markup document.
+     *
      * @param owner
      * The document's owner.
      *
@@ -999,7 +1012,7 @@ public class UILoader {
      * The deserialized component hierarchy.
      */
     public static JComponent load(Object owner, String name, ResourceBundle resourceBundle) {
-        if (owner == null || name == null) {
+        if (name == null) {
             throw new IllegalArgumentException();
         }
 

--- a/sierra/src/main/java/org/httprpc/sierra/UILoader.java
+++ b/sierra/src/main/java/org/httprpc/sierra/UILoader.java
@@ -704,8 +704,12 @@ public class UILoader {
     private InputStream open() throws IOException {
         if (owner != null) {
             return owner.getClass().getResourceAsStream(name);
-        } else {
+        } else if (owner == null && path == null) {
+            return ClassLoader.getSystemResourceAsStream(name);
+        } else if (path != null) {
             return path.toUri().toURL().openStream();
+        } else {
+            throw new AssertionError("should never reach here!");
         }
     }
 


### PR DESCRIPTION
Since UILoader can gracefully handle null values of `owner` objects, we can remove the null check in the static method `load` in UILoader. This works similarly to the `load(Path)` method but it loads from the classpath resources.